### PR TITLE
docs: fix incorrect configuration snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following example assumes that the code is hosted by GitHub.
 - ***pyproject.toml***
 
     ```toml
-    [tool.hatch.metadata.hooks.datadog-build-metadata]
+    [tool.hatch.metadata.hooks.datadog-build-metadata.urls]
     Homepage = "https://www.example.com"
     source_archive = "{remote_http_url}/archive/{commit_hash}.tar.gz"
     ```
@@ -81,7 +81,7 @@ The following example assumes that the code is hosted by GitHub.
 - ***hatch.toml***
 
     ```toml
-    [metadata.hooks.datadog-build-metadata]
+    [metadata.hooks.datadog-build-metadata.urls]
     Homepage = "https://www.example.com"
     source_archive = "{remote_http_url}/archive/{commit_hash}.tar.gz"
     ```


### PR DESCRIPTION
Hey 👋 

While trying to adopt, I noticed that the configuration examples provided in the README do not match the plugin behaviours, which looks in `urls` key.
Here's a small MR to fix that.

Other note: when setting unknown keys at the top-level of the plugin config, no warnings are shown, which could be a further improvement.

Have a great day!